### PR TITLE
feature/ok-and-cancel-button

### DIFF
--- a/lib/core/src/datetimepicker/calendar.html
+++ b/lib/core/src/datetimepicker/calendar.html
@@ -7,6 +7,7 @@
     <span *ngIf="type !== 'time'"
           class="mat-datetimepicker-calendar-header-date"
           [class.active]="_currentView == 'month'"
+          [class.not-clickable]="type === 'month'"
           (click)="_dateClicked()">{{ _dateLabel }}</span>
     <span *ngIf="type.endsWith('time')"
           class="mat-datetimepicker-calendar-header-time"

--- a/lib/core/src/datetimepicker/calendar.html
+++ b/lib/core/src/datetimepicker/calendar.html
@@ -68,4 +68,8 @@
              (selectedChange)="_timeSelected($event)"
              (_userSelection)="_userSelected()">
   </mat-datetimepicker-clock>
+  <div class="mat-datetimepicker-calendar-footer">
+    <button mat-button color="primary" (click)="_handleCancelButton($event)">{{ cancelButtonLabel }}</button>
+    <button mat-raised-button color="primary" (click)="_handlConfirmkButton($event)">{{ confirmButtonLabel }}</button>
+  </div>
 </div>

--- a/lib/core/src/datetimepicker/calendar.scss
+++ b/lib/core/src/datetimepicker/calendar.scss
@@ -91,6 +91,11 @@ $mat-calendar-next-icon-transform: translateX(-2px) rotate(45deg);
   [mode='landscape'] & {
     padding-top: $mat-calendar-padding;
   }
+
+  > .mat-datetimepicker-calendar-footer {
+    padding: 12px;
+    text-align: right;
+  }
 }
 
 .mat-datetimepicker-calendar-controls {

--- a/lib/core/src/datetimepicker/calendar.scss
+++ b/lib/core/src/datetimepicker/calendar.scss
@@ -57,6 +57,9 @@ $mat-calendar-next-icon-transform: translateX(-2px) rotate(45deg);
     cursor: pointer;
     opacity: 0.6;
   }
+  &.not-clickable {
+    cursor: initial;
+  }
 }
 
 .mat-datetimepicker-calendar-header-time {

--- a/lib/core/src/datetimepicker/calendar.ts
+++ b/lib/core/src/datetimepicker/calendar.ts
@@ -271,7 +271,9 @@ export class MatDatetimepickerCalendar<D> implements AfterContentInit, OnDestroy
   }
 
   _dateClicked(): void {
-    this._currentView = "month";
+    if (this.type !== 'month') {
+      this._currentView = "month";
+    }
   }
 
   _hoursClicked(): void {

--- a/lib/core/src/datetimepicker/calendar.ts
+++ b/lib/core/src/datetimepicker/calendar.ts
@@ -240,26 +240,28 @@ export class MatDatetimepickerCalendar<D> implements AfterContentInit, OnDestroy
 
   /** Handles month selection in the year view. */
   _monthSelected(month: D): void {
-    if (this.type == "month") {
-      if (!this._adapter.sameMonthAndYear(month, this.selected)) {
-        this.selectedChange.emit(this._adapter.getFirstDateOfMonth(month));
-      }
-    } else {
-      this._activeDate = month;
+    this._activeDate = month;
+    if (this.type !== 'month') {
       this._currentView = "month";
       this._clockView = "hour";
     }
   }
 
   _timeSelected(date: D): void {
-    if (this._clockView !== "minute") {
-      this._activeDate = date;
-      this._clockView = "minute";
-    } else {
-      if (!this._adapter.sameDatetime(date, this.selected)) {
-        this.selectedChange.emit(date);
-      }
-    }
+    this._activeDate = date;
+    this._clockView = "minute";
+  }
+
+  @Input() confirmButtonLabel: string;
+  _handleConfirmButton(): void {
+    this.selectedChange.emit(this._activeDate);
+    this._userSelected();
+  }
+
+  @Input() cancelButtonLabel: string;
+  _handleCancelButton(): void {
+    // Close dialog (datetimepicker.close())
+    this._userSelection.emit();
   }
 
   _onActiveDateChange(date: D) {

--- a/lib/core/src/datetimepicker/clock.ts
+++ b/lib/core/src/datetimepicker/clock.ts
@@ -182,9 +182,6 @@ export class MatDatetimepickerClock<D> implements AfterContentInit {
     document.removeEventListener("touchend", this.mouseUpListener);
     if (this._timeChanged) {
       this.selectedChange.emit(this.activeDate);
-      if (!this._hourView) {
-        this._userSelection.emit();
-      }
     }
   }
 

--- a/lib/core/src/datetimepicker/datetimepicker-content.html
+++ b/lib/core/src/datetimepicker/datetimepicker-content.html
@@ -9,6 +9,8 @@
               [dateFilter]="datetimepicker._dateFilter"
               [selected]="datetimepicker._selected"
               [startAt]="datetimepicker.startAt"
+              [confirmButtonLabel]="datetimepicker.confirmButtonLabel"
+              [cancelButtonLabel]="datetimepicker.cancelButtonLabel"
               (selectedChange)="datetimepicker._select($event)"
               (_userSelection)="datetimepicker.close()">
 </mat-datetimepicker-calendar>

--- a/lib/core/src/datetimepicker/datetimepicker-content.scss
+++ b/lib/core/src/datetimepicker/datetimepicker-content.scss
@@ -4,8 +4,8 @@ $mat-datetimepicker-calendar-padding: 8px;
 $mat-datetimepicker-calendar-cell-size: 40px;
 $mat-datetimepicker-calendar-portrait-width: $mat-datetimepicker-calendar-cell-size * 7 + $mat-datetimepicker-calendar-padding * 2;
 $mat-datetimepicker-calendar-landscape-width: 446px;
-$mat-datetimepicker-calendar-portrait-height: 405px;
-$mat-datetimepicker-calendar-landscape-height: 328px;
+$mat-datetimepicker-calendar-portrait-height: auto;
+$mat-datetimepicker-calendar-landscape-height: auto;
 
 .mat-datetimepicker-content {
   @include mat-elevation(8);

--- a/lib/core/src/datetimepicker/datetimepicker.ts
+++ b/lib/core/src/datetimepicker/datetimepicker.ts
@@ -176,6 +176,9 @@ export class MatDatetimepicker<D> implements OnDestroy {
   /** Classes to be passed to the date picker panel. Supports the same syntax as `ngClass`. */
   @Input() panelClass: string | string[];
 
+  @Input() confirmButtonLabel = 'Confirm';
+  @Input() cancelButtonLabel = 'Cancel';
+
   /** Emits when the datepicker has been opened. */
   @Output("opened") openedStream: EventEmitter<void> = new EventEmitter<void>();
 

--- a/lib/core/src/datetimepicker/month-view.ts
+++ b/lib/core/src/datetimepicker/month-view.ts
@@ -136,9 +136,6 @@ export class MatDatetimepickerMonthView<D> implements AfterContentInit {
       this._adapter.getYear(this.activeDate), this._adapter.getMonth(this.activeDate),
       date, this._adapter.getHour(this.activeDate),
       this._adapter.getMinute(this.activeDate)));
-    if (this.type === "date") {
-      this._userSelection.emit();
-    }
   }
 
   /** Initializes this month view. */

--- a/lib/core/src/datetimepicker/year-view.ts
+++ b/lib/core/src/datetimepicker/year-view.ts
@@ -120,9 +120,8 @@ export class MatDatetimepickerYearView<D> implements AfterContentInit {
       this._adapter.getDate(this.activeDate),
       this._adapter.getHour(this.activeDate),
       this._adapter.getMinute(this.activeDate)));
-    if (this.type === "month") {
-      this._userSelection.emit();
-    }
+
+    this._selectedMonth = month;
   }
 
   /** Initializes this month view. */

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -37,6 +37,12 @@
     <mat-datetimepicker-toggle [for]="minTestPicker" matSuffix></mat-datetimepicker-toggle>
     <mat-datetimepicker #minTestPicker type="datetime" openOnFocus="true" mode="landscape" timeInterval="5"></mat-datetimepicker>
   </mat-form-field>
+  <mat-form-field>
+    <mat-placeholder>Min Test</mat-placeholder>
+    <input matInput formControlName="mintestPortrait" [min]="min" [matDatetimepicker]="minTestPickerPortrait" required>
+    <mat-datetimepicker-toggle [for]="minTestPickerPortrait" matSuffix></mat-datetimepicker-toggle>
+    <mat-datetimepicker #minTestPickerPortrait type="datetime" openOnFocus="true" mode="portrait" timeInterval="5" confirmButtonLabel="Hey" cancelButtonLabel="Yo"></mat-datetimepicker>
+  </mat-form-field>
 </form>
 <ul>
   <li>
@@ -49,4 +55,3 @@
     <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
   </li>
 </ul>
-


### PR DESCRIPTION
Added new Confirm and Cancel buttons.

The `datetimepicker` don't close when the last option is selected, like when was closing automatically after time selection.

I added this because I had a problem when I  wanted to change only the month, and needed to select a option in all steps (or navigate to minutes and re-select the minutes option.